### PR TITLE
0.0.2 for develop (fixed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2] - 2023-09-17
+
+### Added
+
+- Initial frontend client implementation using [React](https://react.dev/) and [Apollo](https://www.apollographql.com/docs/react/) following the [React + Apollo Tutorial](https://www.howtographql.com/react-apollo/0-introduction/) from [How To GraphQL](https://www.howtographql.com/). This release includes through the [Part 5 - Authentication](https://www.howtographql.com/react-apollo/5-authentication/) section of the tutorial.
+
+## [0.0.1] - 2023-09-10
+
+### Added
+
+- Initial backend server implementation of [GraphQL](https://graphql.org/) in [Golang](https://go.dev/) following the [graphql-go Tutorial](https://www.howtographql.com/graphql-go/0-introduction/) from [How To GraphQL](https://www.howtographql.com/).
+
+[unreleased]: https://github.com/danieljmehler/hackernews-go-graphql/compare/0.0.2...HEAD
+[0.0.2]: https://github.com/danieljmehler/hackernews-go-graphql/compare/0.0.1...0.0.2
+[0.0.1]: https://github.com/danieljmehler/hackernews-go-graphql/releases/tag/0.0.1

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # hackernews
 
 Hackernews clone using GraphQL, with server written in Golang and client written in React.
+
+* [server](https://www.howtographql.com/graphql-go/1-getting-started/)
+* [client](https://www.howtographql.com/react-apollo/1-getting-started/)

--- a/server/README.md
+++ b/server/README.md
@@ -1,5 +1,6 @@
 # hackernews-go-graphql
-https://www.howtographql.com/graphql-go/1-getting-started/
+
+([ref](https://www.howtographql.com/graphql-go/1-getting-started/))
 
 ## Starting a MySQL database in WSL2
 


### PR DESCRIPTION
### Added

- Initial frontend client implementation using [React](https://react.dev/) and [Apollo](https://www.apollographql.com/docs/react/) following the [React + Apollo Tutorial](https://www.howtographql.com/react-apollo/0-introduction/) from [How To GraphQL](https://www.howtographql.com/). This release includes through the [Part 5 - Authentication](https://www.howtographql.com/react-apollo/5-authentication/) section of the tutorial.